### PR TITLE
AW suits are now for sale

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -329,6 +329,12 @@ uplink-hardsuit-syndieelite-desc = An elite version of the blood-red hardsuit, w
 uplink-clothing-outer-hardsuit-juggernaut-name = Cybersun Juggernaut Suit
 uplink-clothing-outer-hardsuit-juggernaut-desc = Hyper resilient armor made of materials tested in the Tau chromosphere facility. The only thing that's going to be slowing you down is this suit... and tasers.
 
+uplink-hardsuit-atomwaffen-name = Atomwaffen hardsuit
+uplink-hardsuit-atomwaffen-desc = A black and white combat hardsuit designed for Atomwaffen terrorists.
+
+uplink-hardsuit-atomwaffenelite-name = Atomwaffen elite hardsuit
+uplink-hardsuit-atomwaffenelite-desc = An upgraded Atomwaffen hardsuit with some of the ballistic armor converted to resist lasers, fire and radiation exceptionally more.
+
 # Misc
 uplink-cyberpen-name = Cybersun Pen
 uplink-cyberpen-desc = Cybersun's legal department pen, invaluable for forging documents and escaping prisons. Smells vaguely of hard-light and war profiteering.

--- a/Resources/Prototypes/BorealStation/Catalog/Fills/Backpacks/duffelbag.yml
+++ b/Resources/Prototypes/BorealStation/Catalog/Fills/Backpacks/duffelbag.yml
@@ -1,0 +1,27 @@
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelAtomwaffenHardsuitBundle
+  name: atomwaffen hardsuit bundle
+  description: "Contains the Dreaded Atomwaffen hardsuit."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterHardsuitAtomwaffen
+      - id: ClothingMaskGasSyndicate
+      - id: ClothingHandsGlovesCombat
+      - id: DoubleEmergencyOxygenTankFilled
+      - id: DoubleEmergencyNitrogenTankFilled
+
+- type: entity
+  parent: ClothingBackpackDuffelSyndicateBundle
+  id: ClothingBackpackDuffelAtomwaffenEliteHardsuitBundle
+  name: atomwaffen elite hardsuit bundle
+  description: "Contains Atomwaffen's elite hardsuit."
+  components:
+  - type: StorageFill
+    contents:
+      - id: ClothingOuterHardsuitAtomwaffenElite
+      - id: ClothingMaskGasSyndicate
+      - id: ClothingHandsGlovesCombat
+      - id: DoubleEmergencyOxygenTankFilled
+      - id: DoubleEmergencyNitrogenTankFilled

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1080,7 +1080,7 @@
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio-borg-assault }
   cost:
     # Goobstation - Telecrystal rework
-    Telecrystal: 375
+    Telecrystal: 325
   categories:
     - UplinkAllies
   conditions:
@@ -1483,11 +1483,11 @@
   saleLimit: 1 # WD EDIT
 
 - type: listing
-  id: UplinkHardsuitSyndie
-  name: uplink-hardsuit-syndie-name
-  description: uplink-hardsuit-syndie-desc
-  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndicate.rsi, state: icon }
-  productEntity: ClothingBackpackDuffelSyndicateHardsuitBundle
+  id: UplinkHardsuitAtomwaffen # BOREAL STATION in the future, separate this and syndicate purchases, so syndicate operatives buy bloodreds while AW buys AW suits
+  name: uplink-hardsuit-atomwaffen-name # BOREAL STATION
+  description: uplink-hardsuit-atomwaffen-desc # BOREAL STATION
+  icon: { sprite: /Textures/BorealStation/Clothing/OuterClothing/Hardsuits/atomwaffen.rsi, state: icon } # BOREAL STATION
+  productEntity: ClothingBackpackDuffelAtomwaffenHardsuitBundle # BOREAL STATION
   cost:
     # Goobstation - Telecrystal rework
     Telecrystal: 40
@@ -1513,11 +1513,11 @@
   saleLimit: 1 # WD EDIT
 
 - type: listing
-  id: UplinkHardsuitSyndieElite
-  name: uplink-hardsuit-syndieelite-name
-  description: uplink-hardsuit-syndieelite-desc
-  icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
-  productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
+  id: UplinkHardsuitAtomwaffenElite # BOREAL STATION
+  name: uplink-hardsuit-atomwaffenelite-name # BOREAL STATION
+  description: uplink-hardsuit-atomwaffenelite-desc # BOREAL STATION
+  icon: { sprite: /Textures/BorealStation/Clothing/OuterClothing/Hardsuits/atomwaffenelite.rsi, state: icon } # BOREAL STATION
+  productEntity: ClothingBackpackDuffelAtomwaffenEliteHardsuitBundle # BOREAL STATION
   cost:
     # Goobstation - Telecrystal rework
     Telecrystal: 70


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
the correct suits are now available for purchase
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/5b9ba471-89f6-4d01-83a5-0f6c4d858b8e)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Atomwaffen suits are now available for puchase in the uplink, for now replacing the bloodred and elite hardsuits
