### PR TITLE
adds two ships

### DIFF
--- a/Resources/Maps/Shuttles/HaunebuV.yml
+++ b/Resources/Maps/Shuttles/HaunebuV.yml
@@ -1,0 +1,1867 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  83: FloorReinforced
+  87: FloorShuttleBlack
+  92: FloorShuttleRed
+  129: Lattice
+  130: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Haunebu V
+    - type: Transform
+      pos: -0.56774205,0.4954834
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: XAAAAAAAXAAAAAAAVwAAAAAAXAAAAAAAXAAAAAAAUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAXAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAggAAAAAAVwAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUwAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAgQAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgQAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAVwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAXAAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAVwAAAAAAggAAAAAAgQAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVwAAAAAAVwAAAAAAVwAAAAAAXAAAAAAAVwAAAAAAgQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXAAAAAAAXAAAAAAAVwAAAAAAXAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes: []
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65535
+          0,-1:
+            0: 65523
+            1: 8
+          -1,0:
+            0: 61439
+            1: 4096
+          0,1:
+            0: 7
+            1: 72
+          -1,1:
+            0: 12
+            1: 67
+          1,0:
+            0: 273
+            1: 4608
+          1,1:
+            1: 1
+          1,-1:
+            0: 4352
+            1: 529
+          -2,0:
+            1: 2048
+          -1,-1:
+            0: 65512
+            1: 19
+          -2,-1:
+            1: 2048
+          -1,-2:
+            1: 16384
+          0,-2:
+            0: 4096
+            1: 16384
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirCanister
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+- proto: AirlockExternalShuttleSyndicateLocked
+  entities:
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+- proto: APCHighCapacity
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 1
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+- proto: BlastDoor
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+- proto: BlastDoorWindowsOpen
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+- proto: ClothingOuterHardsuitBasic
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 80
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 81
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 82
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ComputerIFFSyndicate
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+- proto: ComputerShuttleSyndie
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: DoubleEmergencyNitrogenTankFilled
+  entities:
+  - uid: 17
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 18
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 19
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 20
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: DoubleEmergencyOxygenTankFilled
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 76
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 77
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 79
+    components:
+    - type: Transform
+      parent: 74
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: GasPassiveVent
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 212
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 213
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 214
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 215
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 202
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 216
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+- proto: LockerMedicine
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+    - type: Lock
+      locked: False
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.1462
+        moles:
+        - 1.8744951
+        - 7.051672
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 25
+          - 24
+          - 23
+          - 22
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LockerSyndicatePersonal
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 163
+          - 162
+          - 161
+          - 160
+          - 159
+          - 158
+          - 157
+          - 156
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: MagazineGrenadeBlast
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      parent: 144
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+  - uid: 156
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 157
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 160
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: MagazineGrenadeEMP
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 161
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: MagazineGrenadeFrag
+  entities:
+  - uid: 158
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 162
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 163
+    components:
+    - type: Transform
+      parent: 155
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 22
+    components:
+    - type: Transform
+      parent: 21
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 23
+    components:
+    - type: Transform
+      parent: 21
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 24
+    components:
+    - type: Transform
+      parent: 21
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 25
+    components:
+    - type: Transform
+      parent: 21
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: OxygenCanister
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+- proto: PlastitaniumWindow
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+- proto: PowerCellHigh
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      parent: 145
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+  - uid: 30
+    components:
+    - type: Transform
+      parent: 146
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -3.6053998,-0.30651474
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -3.5845563,-0.62965655
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 4.669538,-0.31693912
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 4.6591163,-0.62965655
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+- proto: ShuttleGunDuster
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 27
+- proto: ShuttleGunSvalinnMachineGun
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 29
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        machine_board: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        machine_parts: !type:Container
+          showEnts: False
+          occludes: True
+          ents: []
+        gun_magazine: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: 30
+- proto: SignalButton
+  entities:
+  - uid: 149
+    components:
+    - type: MetaData
+      name: fire
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        146:
+        - Pressed: Toggle
+        - Pressed: Trigger
+        143:
+        - Pressed: Open
+  - uid: 151
+    components:
+    - type: MetaData
+      name: fire
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        145:
+        - Pressed: Toggle
+        - Pressed: Trigger
+        141:
+        - Pressed: Open
+  - uid: 164
+    components:
+    - type: MetaData
+      name: open shutter
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        143:
+        - Pressed: Toggle
+  - uid: 165
+    components:
+    - type: MetaData
+      name: open shutter
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        142:
+        - Pressed: Toggle
+  - uid: 166
+    components:
+    - type: MetaData
+      name: open shutter
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        141:
+        - Pressed: Toggle
+  - uid: 173
+    components:
+    - type: MetaData
+      name: fire
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        144:
+        - Pressed: Trigger
+        142:
+        - Pressed: Open
+- proto: SignalButtonWindows
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+- proto: SuitStorageBase
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 19
+          - 75
+          - 76
+          - 77
+          - 78
+          - 17
+          - 18
+          - 79
+          - 20
+          - 80
+          - 81
+          - 82
+- proto: TableReinforced
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+- proto: ToolboxSyndicateFilled
+  entities:
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 1.4432309,1.6811471
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 1.4432309,1.6811471
+      parent: 1
+- proto: TurboItemRecharger
+  entities:
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+- proto: VendingMachineSustenance
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+- proto: WallPlastitaniumDiagonal
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+- proto: WindoorSecureSyndicateLocked
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+...

--- a/Resources/Maps/Shuttles/WindmillOfPeaceBattlecruiser.yml
+++ b/Resources/Maps/Shuttles/WindmillOfPeaceBattlecruiser.yml
@@ -1,0 +1,8672 @@
+meta:
+  format: 6
+  postmapinit: false
+tilemap:
+  0: Space
+  32: FloorDark
+  68: FloorMetalDiamond
+  84: FloorReinforcedHardened
+  92: FloorShuttleRed
+  93: FloorShuttleWhite
+  130: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Atomwaffen "Windmill of Peace" Battlecruiser
+    - type: Transform
+      pos: 0.7856951,15.655903
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,-2:
+          ind: 0,-2
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAA
+          version: 6
+        1,-2:
+          ind: 1,-2
+          tiles: XAAAAAAAXAAAAAAAXAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAXAAAAAAAXAAAAAAAXAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAXQAAAAAAXQAAAAAAXQAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAARAAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAARAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAA
+          version: 6
+        0,-3:
+          ind: 0,-3
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAARAAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAVAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAA
+          version: 6
+        1,-3:
+          ind: 1,-3
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAARAAAAAAARAAAAAAARAAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAggAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAIAAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAAggAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            angle: 0.7853981633974483 rad
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineE
+          decals:
+            56: 16.89508,-31.45678
+            58: 16.36383,-30.92553
+            59: 15.816956,-31.409904
+            62: 17.42633,-30.98803
+        - node:
+            angle: 0.7853981633974483 rad
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            51: 17.394852,-32.013596
+            57: 16.86383,-31.503654
+            60: 16.879456,-30.36303
+            61: 17.410706,-30.95678
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelCornerNe
+          decals:
+            84: 18,-26
+            109: 14,-19
+            114: 22,-30
+            144: 25,-41
+            154: 18,-38
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelCornerNw
+          decals:
+            85: 16,-26
+            104: 9,-19
+            119: 12,-30
+            129: 16,-38
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelCornerSe
+          decals:
+            88: 18,-24
+            115: 22,-32
+            124: 18,-36
+            143: 25,-43
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelCornerSw
+          decals:
+            89: 16,-24
+            103: 9,-21
+            120: 12,-32
+            123: 16,-36
+            134: 16,-43
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelInnerNe
+          decals:
+            66: 15,-33
+            111: 14,-20
+            151: 18,-41
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelInnerNw
+          decals:
+            67: 19,-33
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelInnerSe
+          decals:
+            69: 15,-29
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelInnerSw
+          decals:
+            68: 19,-29
+            96: 16,-21
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelLineE
+          decals:
+            63: 15,-30
+            64: 15,-31
+            65: 15,-32
+            82: 18,-28
+            83: 18,-27
+            90: 18,-23
+            91: 18,-22
+            92: 18,-21
+            125: 18,-35
+            126: 18,-34
+            152: 18,-40
+            153: 18,-39
+            173: 18,-20
+        - node:
+            angle: 0.7853981633974483 rad
+            color: '#AE0005FF'
+            id: MiniTileSteelLineE
+          decals:
+            155: 18.550285,-29.223381
+            156: 18.956535,-29.598381
+            157: 18.31591,-29.004631
+            158: 15.058589,-33.522186
+            159: 14.496089,-32.959686
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelLineN
+          decals:
+            70: 16,-33
+            71: 17,-33
+            72: 18,-33
+            80: 13,-30
+            81: 14,-30
+            105: 10,-19
+            106: 11,-19
+            107: 12,-19
+            108: 13,-19
+            110: 15,-20
+            112: 20,-30
+            113: 21,-30
+            145: 24,-41
+            146: 23,-41
+            147: 22,-41
+            148: 21,-41
+            149: 20,-41
+            150: 19,-41
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelLineS
+          decals:
+            73: 16,-29
+            74: 17,-29
+            75: 18,-29
+            97: 15,-21
+            98: 14,-21
+            99: 13,-21
+            100: 12,-21
+            101: 11,-21
+            102: 10,-21
+            116: 21,-32
+            117: 20,-32
+            121: 13,-32
+            122: 14,-32
+            135: 17,-43
+            136: 18,-43
+            137: 19,-43
+            138: 20,-43
+            139: 21,-43
+            140: 22,-43
+            141: 23,-43
+            142: 24,-43
+        - node:
+            angle: 0.7853981633974483 rad
+            color: '#AE0005FF'
+            id: MiniTileSteelLineS
+          decals:
+            160: 18.39457,-33.04335
+            161: 19.035194,-32.3871
+            162: 14.538184,-29.024988
+            163: 15.085059,-28.478113
+        - node:
+            color: '#AE0005FF'
+            id: MiniTileSteelLineW
+          decals:
+            76: 19,-30
+            77: 19,-31
+            78: 19,-32
+            86: 16,-27
+            87: 16,-28
+            94: 16,-23
+            95: 16,-22
+            127: 16,-35
+            128: 16,-34
+            130: 16,-39
+            131: 16,-40
+            132: 16,-41
+            133: 16,-42
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNe
+          decals:
+            198: 29,-23
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerNw
+          decals:
+            196: 24,-30
+            197: 27,-23
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerSe
+          decals:
+            200: 29,-32
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteCornerSw
+          decals:
+            199: 24,-32
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteInnerNw
+          decals:
+            209: 27,-30
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineE
+          decals:
+            214: 29,-31
+            215: 29,-30
+            216: 29,-29
+            217: 29,-28
+            218: 29,-27
+            219: 29,-26
+            220: 29,-25
+            221: 29,-24
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineN
+          decals:
+            207: 25,-30
+            208: 26,-30
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineS
+          decals:
+            210: 28,-32
+            211: 27,-32
+            212: 26,-32
+            213: 25,-32
+        - node:
+            color: '#52B4E996'
+            id: MiniTileWhiteLineW
+          decals:
+            201: 27,-24
+            202: 27,-25
+            203: 27,-26
+            204: 27,-27
+            205: 27,-28
+            206: 27,-29
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnFull
+          decals:
+            12: 27,-19
+            13: 28,-19
+            14: 29,-19
+            15: 28,-18
+            16: 4,-20
+            17: 5,-19
+            18: 5,-20
+            19: 5,-21
+            20: 5,-43
+            21: 6,-43
+            22: 7,-43
+            23: 6,-44
+            24: 29,-41
+            25: 29,-42
+            26: 29,-43
+            27: 30,-42
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            175: 25,-42
+            177: 10,-31
+            178: 7,-20
+            182: 22,-31
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            167: 17,-36
+            168: 17,-24
+            180: 28,-21
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            164: 12,-31
+            165: 9,-20
+            166: 24,-31
+            176: 27,-42
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            169: 16,-20
+            170: 17,-20
+            172: 18,-20
+            174: 17,-38
+            179: 28,-23
+        - node:
+            color: '#FFFFFFFF'
+            id: d
+          decals:
+            193: 29,-19
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: d
+          decals:
+            192: 5,-19
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: d
+          decals:
+            191: 5,-43
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: d
+          decals:
+            194: 29,-43
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: n
+          decals:
+            190: 6,-43
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: n
+          decals:
+            187: 5,-20
+            189: 29,-42
+        - node:
+            angle: 6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: n
+          decals:
+            188: 28,-19
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: t
+          decals:
+            183: 5,-21
+        - node:
+            angle: 3.141592653589793 rad
+            color: '#FFFFFFFF'
+            id: t
+          decals:
+            184: 7,-43
+        - node:
+            angle: 4.71238898038469 rad
+            color: '#FFFFFFFF'
+            id: t
+          decals:
+            185: 29,-41
+        - node:
+            angle: 6.283185307179586 rad
+            color: '#FFFFFFFF'
+            id: t
+          decals:
+            186: 27,-19
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,-8:
+            0: 34952
+          0,-9:
+            0: 34952
+          0,-7:
+            0: 8
+          1,-7:
+            0: 15
+          0,-6:
+            0: 34944
+          1,-6:
+            0: 57584
+          0,-5:
+            0: 34952
+          1,-5:
+            0: 61678
+          1,-8:
+            0: 3822
+          1,-9:
+            0: 61158
+            2: 8
+          2,-8:
+            0: 2039
+          2,-7:
+            0: 15
+          2,-6:
+            0: 57584
+          2,-5:
+            0: 61679
+          3,-8:
+            0: 36863
+          3,-7:
+            0: 17479
+          3,-6:
+            0: 61556
+          3,-5:
+            0: 28799
+          3,-9:
+            0: 34628
+          4,-8:
+            0: 65535
+          4,-7:
+            0: 10103
+          4,-6:
+            0: 30583
+          4,-5:
+            0: 30583
+          4,-9:
+            0: 63351
+          5,-8:
+            0: 2039
+          5,-7:
+            0: 4383
+          5,-6:
+            0: 4369
+          5,-5:
+            0: 4369
+          6,-8:
+            0: 36863
+          6,-7:
+            0: 43691
+          6,-6:
+            0: 41642
+          6,-5:
+            0: 58026
+          7,-8:
+            0: 48059
+          7,-7:
+            0: 48059
+          7,-6:
+            0: 47547
+          7,-5:
+            0: 63675
+          7,-9:
+            0: 36608
+          0,-12:
+            0: 32768
+          0,-11:
+            0: 34952
+          1,-12:
+            0: 61440
+          0,-10:
+            0: 34952
+          1,-11:
+            0: 61152
+          1,-10:
+            0: 26212
+            1: 2176
+            2: 32768
+          2,-12:
+            0: 12288
+          2,-11:
+            0: 8738
+          2,-10:
+            0: 8738
+          2,-9:
+            0: 3618
+          3,-12:
+            0: 49152
+          3,-11:
+            0: 17476
+          3,-10:
+            0: 17476
+          4,-12:
+            0: 61440
+          4,-11:
+            0: 65520
+          4,-10:
+            0: 10103
+          5,-12:
+            0: 61440
+          5,-11:
+            0: 65520
+          5,-10:
+            0: 4592
+          5,-9:
+            0: 3857
+          6,-12:
+            0: 61440
+          6,-11:
+            0: 49072
+          6,-10:
+            0: 240
+          6,-9:
+            0: 3840
+          7,-12:
+            0: 61440
+          7,-11:
+            0: 48056
+          7,-10:
+            0: 248
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+- proto: AirlockExternalGlassNukeopLocked
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-18.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-18.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-18.5
+      parent: 1
+- proto: AirlockExternalShuttleNukeopLocked
+  entities:
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-16.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-16.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-16.5
+      parent: 1
+- proto: AirlockSyndicateNukeopLocked
+  entities:
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-24.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-30.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 23.5,-30.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-36.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-39.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-41.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-19.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 28.5,-21.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-21.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 26.5,-27.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-38.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-31.5
+      parent: 1
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 20
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-19.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 6.5,-43.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 30.5,-41.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-17.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-16.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-16.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-16.5
+      parent: 1
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-38.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-37.5
+      parent: 1
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-36.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-35.5
+      parent: 1
+- proto: BannerSyndicate
+  entities:
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 12.5,-31.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 12.5,-29.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 22.5,-29.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 22.5,-31.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 18.5,-35.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 16.5,-35.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 18.5,-25.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 38
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-28.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-26.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-24.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-28.5
+      parent: 1
+- proto: BedsheetSyndie
+  entities:
+  - uid: 42
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-26.5
+      parent: 1
+- proto: BlastDoor
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-43.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 28.5,-17.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 2
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.5,-19.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 30.5,-41.5
+      parent: 1
+- proto: BoxFolderNuclearCodes
+  entities:
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 16.437218,-39.373367
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 1182
+    components:
+    - type: Transform
+      pos: 16.629059,-39.50076
+      parent: 1
+- proto: BoxMagazinePistolSubMachineGun
+  entities:
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 21.518723,-42.410583
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: CableApcExtension
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 14.5,-20.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 11.5,-30.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 6.5,-40.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 10.5,-30.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 8.5,-30.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 9.5,-30.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 6.5,-35.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 6.5,-37.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 6.5,-39.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,-38.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 6.5,-41.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 5.5,-36.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 6.5,-36.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 6.5,-34.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 6.5,-33.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 6.5,-32.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 6.5,-31.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 6.5,-30.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 7.5,-30.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: 6.5,-30.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: 11.5,-31.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: 13.5,-31.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 14.5,-31.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 15.5,-31.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: 12.5,-31.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: 17.5,-31.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 16.5,-31.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 19.5,-38.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 18.5,-38.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 17.5,-39.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 17.5,-41.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 17.5,-40.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 18.5,-41.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 20.5,-41.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 21.5,-41.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 22.5,-41.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 23.5,-41.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 25.5,-41.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 19.5,-41.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 26.5,-41.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 27.5,-41.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 28.5,-41.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 24.5,-41.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 29.5,-41.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 30.5,-41.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 31.5,-41.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 31.5,-40.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 31.5,-38.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: 31.5,-39.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 30.5,-38.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 28.5,-38.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 27.5,-38.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 26.5,-38.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 29.5,-38.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 25.5,-38.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 22.5,-38.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 21.5,-38.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 23.5,-38.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 24.5,-38.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 14.5,-21.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 12.5,-20.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 11.5,-20.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 10.5,-20.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 9.5,-20.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 28.5,-21.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 7.5,-20.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 6.5,-20.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 13.5,-20.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 3.5,-20.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 5.5,-20.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 3.5,-21.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 3.5,-22.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 14.5,-23.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 4.5,-22.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 6.5,-22.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 5.5,-22.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 7.5,-22.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 9.5,-22.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 10.5,-22.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 11.5,-22.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 8.5,-22.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 14.5,-22.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 12.5,-22.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 13.5,-22.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 14.5,-25.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 14.5,-26.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 14.5,-27.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 14.5,-24.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 13.5,-27.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 11.5,-27.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 10.5,-27.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 9.5,-27.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 8.5,-27.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 7.5,-27.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 12.5,-27.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 6.5,-27.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 3.5,-27.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 4.5,-27.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 5.5,-27.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 3.5,-44.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 3.5,-41.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 3.5,-43.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 3.5,-28.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 3.5,-30.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 3.5,-31.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 3.5,-32.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 3.5,-33.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 3.5,-34.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 3.5,-29.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 3.5,-36.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 3.5,-37.5
+      parent: 1
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 3.5,-38.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: 3.5,-35.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 3.5,-40.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 3.5,-39.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 3.5,-42.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 4.5,-44.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: 6.5,-44.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 7.5,-44.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 8.5,-44.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 9.5,-44.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 5.5,-44.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 14.5,-34.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 9.5,-43.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 9.5,-42.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 9.5,-41.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 9.5,-40.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 9.5,-39.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 9.5,-38.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 9.5,-37.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 9.5,-36.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 9.5,-35.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 9.5,-34.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 9.5,-33.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 10.5,-33.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 12.5,-33.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 13.5,-33.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 14.5,-33.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 11.5,-33.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 14.5,-36.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 14.5,-37.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 14.5,-38.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 14.5,-39.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 14.5,-40.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 14.5,-41.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 14.5,-43.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 14.5,-44.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 14.5,-35.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 14.5,-42.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 20.5,-26.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 27.5,-27.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 26.5,-27.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 27.5,-26.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 27.5,-24.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 27.5,-23.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 27.5,-22.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 28.5,-20.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 27.5,-20.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 27.5,-19.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 27.5,-17.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 27.5,-25.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 27.5,-18.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 27.5,-16.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 26.5,-16.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 25.5,-16.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 25.5,-17.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 25.5,-19.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 25.5,-20.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 25.5,-21.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 25.5,-22.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 25.5,-18.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 25.5,-23.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 25.5,-25.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 25.5,-26.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 25.5,-27.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 25.5,-24.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 24.5,-27.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 22.5,-27.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 21.5,-27.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 20.5,-27.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 23.5,-27.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 20.5,-24.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 20.5,-23.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 20.5,-25.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 20.5,-38.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 20.5,-37.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 20.5,-35.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 20.5,-34.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 20.5,-33.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 20.5,-36.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 21.5,-33.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 23.5,-33.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 24.5,-33.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 22.5,-33.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 15.5,-20.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 16.5,-20.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 16.5,-19.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 16.5,-18.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 18.5,-18.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 17.5,-18.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 16.5,-17.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 16.5,-16.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 18.5,-16.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 17.5,-16.5
+      parent: 1
+  - uid: 1206
+    components:
+    - type: Transform
+      pos: 17.5,-20.5
+      parent: 1
+  - uid: 1241
+    components:
+    - type: Transform
+      pos: 17.5,-22.5
+      parent: 1
+  - uid: 1242
+    components:
+    - type: Transform
+      pos: 17.5,-23.5
+      parent: 1
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: 17.5,-21.5
+      parent: 1
+  - uid: 1244
+    components:
+    - type: Transform
+      pos: 28.5,-26.5
+      parent: 1
+  - uid: 1245
+    components:
+    - type: Transform
+      pos: 17.5,-32.5
+      parent: 1
+  - uid: 1246
+    components:
+    - type: Transform
+      pos: 17.5,-34.5
+      parent: 1
+  - uid: 1247
+    components:
+    - type: Transform
+      pos: 17.5,-35.5
+      parent: 1
+  - uid: 1248
+    components:
+    - type: Transform
+      pos: 17.5,-33.5
+      parent: 1
+  - uid: 1249
+    components:
+    - type: Transform
+      pos: 17.5,-30.5
+      parent: 1
+  - uid: 1250
+    components:
+    - type: Transform
+      pos: 17.5,-29.5
+      parent: 1
+  - uid: 1251
+    components:
+    - type: Transform
+      pos: 17.5,-27.5
+      parent: 1
+  - uid: 1252
+    components:
+    - type: Transform
+      pos: 17.5,-26.5
+      parent: 1
+  - uid: 1253
+    components:
+    - type: Transform
+      pos: 17.5,-28.5
+      parent: 1
+  - uid: 1254
+    components:
+    - type: Transform
+      pos: 18.5,-30.5
+      parent: 1
+  - uid: 1255
+    components:
+    - type: Transform
+      pos: 19.5,-30.5
+      parent: 1
+  - uid: 1256
+    components:
+    - type: Transform
+      pos: 21.5,-30.5
+      parent: 1
+  - uid: 1257
+    components:
+    - type: Transform
+      pos: 22.5,-30.5
+      parent: 1
+  - uid: 1258
+    components:
+    - type: Transform
+      pos: 20.5,-30.5
+      parent: 1
+  - uid: 1259
+    components:
+    - type: Transform
+      pos: 27.5,-28.5
+      parent: 1
+  - uid: 1260
+    components:
+    - type: Transform
+      pos: 27.5,-29.5
+      parent: 1
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: 27.5,-30.5
+      parent: 1
+  - uid: 1262
+    components:
+    - type: Transform
+      pos: 26.5,-30.5
+      parent: 1
+  - uid: 1263
+    components:
+    - type: Transform
+      pos: 25.5,-30.5
+      parent: 1
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: 28.5,-30.5
+      parent: 1
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: 28.5,-22.5
+      parent: 1
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: 29.5,-17.5
+      parent: 1
+  - uid: 1270
+    components:
+    - type: Transform
+      pos: 18.5,-21.5
+      parent: 1
+  - uid: 1271
+    components:
+    - type: Transform
+      pos: 19.5,-21.5
+      parent: 1
+  - uid: 1272
+    components:
+    - type: Transform
+      pos: 19.5,-22.5
+      parent: 1
+  - uid: 1317
+    components:
+    - type: Transform
+      pos: 8.5,-29.5
+      parent: 1
+  - uid: 1336
+    components:
+    - type: Transform
+      pos: 7.5,-43.5
+      parent: 1
+  - uid: 1337
+    components:
+    - type: Transform
+      pos: 5.5,-43.5
+      parent: 1
+  - uid: 1338
+    components:
+    - type: Transform
+      pos: 30.5,-40.5
+      parent: 1
+  - uid: 1339
+    components:
+    - type: Transform
+      pos: 30.5,-42.5
+      parent: 1
+  - uid: 1340
+    components:
+    - type: Transform
+      pos: 28.5,-17.5
+      parent: 1
+  - uid: 1341
+    components:
+    - type: Transform
+      pos: 4.5,-19.5
+      parent: 1
+  - uid: 1342
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 1
+  - uid: 1343
+    components:
+    - type: Transform
+      pos: 7.5,-19.5
+      parent: 1
+  - uid: 1344
+    components:
+    - type: Transform
+      pos: 8.5,-19.5
+      parent: 1
+  - uid: 1345
+    components:
+    - type: Transform
+      pos: 9.5,-19.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 7.5,-32.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 5.5,-30.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 7.5,-30.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 6.5,-30.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 6.5,-31.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 6.5,-33.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 6.5,-32.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 9.5,-30.5
+      parent: 1
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 9.5,-31.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      pos: 9.5,-29.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: 5.5,-32.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 5.5,-33.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: 7.5,-33.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 5.5,-34.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 10.5,-31.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 10.5,-29.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 8.5,-29.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 8.5,-31.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 7.5,-29.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 5.5,-29.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: 6.5,-29.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 8.5,-30.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 7.5,-28.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 5.5,-28.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 6.5,-28.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 9.5,-29.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 9.5,-31.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 9.5,-30.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 10.5,-30.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 11.5,-30.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 11.5,-31.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 12.5,-30.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 14.5,-30.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 13.5,-30.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 17.5,-30.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 19.5,-30.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 18.5,-30.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 20.5,-30.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 21.5,-30.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 22.5,-30.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 24.5,-30.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 23.5,-30.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 25.5,-30.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 26.5,-30.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 27.5,-30.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 27.5,-29.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 27.5,-28.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 27.5,-27.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 26.5,-27.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 17.5,-31.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 17.5,-33.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 17.5,-34.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 17.5,-35.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 17.5,-36.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 17.5,-32.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 17.5,-37.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 18.5,-38.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 19.5,-38.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 17.5,-28.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 17.5,-26.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 17.5,-25.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 17.5,-24.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 17.5,-23.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 17.5,-22.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 17.5,-21.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 17.5,-20.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 17.5,-27.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 16.5,-20.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 14.5,-20.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 15.5,-20.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 14.5,-21.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 17.5,-29.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 10.5,-31.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 10.5,-29.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 15.5,-30.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 16.5,-30.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 8.5,-31.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 8.5,-29.5
+      parent: 1
+  - uid: 1207
+    components:
+    - type: Transform
+      pos: 13.5,-31.5
+      parent: 1
+  - uid: 1208
+    components:
+    - type: Transform
+      pos: 13.5,-32.5
+      parent: 1
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 12.5,-32.5
+      parent: 1
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: 14.5,-32.5
+      parent: 1
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: 15.5,-32.5
+      parent: 1
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: 15.5,-33.5
+      parent: 1
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: 15.5,-34.5
+      parent: 1
+  - uid: 1214
+    components:
+    - type: Transform
+      pos: 15.5,-35.5
+      parent: 1
+  - uid: 1215
+    components:
+    - type: Transform
+      pos: 16.5,-34.5
+      parent: 1
+  - uid: 1216
+    components:
+    - type: Transform
+      pos: 18.5,-34.5
+      parent: 1
+  - uid: 1217
+    components:
+    - type: Transform
+      pos: 19.5,-34.5
+      parent: 1
+  - uid: 1218
+    components:
+    - type: Transform
+      pos: 19.5,-35.5
+      parent: 1
+  - uid: 1219
+    components:
+    - type: Transform
+      pos: 19.5,-33.5
+      parent: 1
+  - uid: 1220
+    components:
+    - type: Transform
+      pos: 19.5,-32.5
+      parent: 1
+  - uid: 1221
+    components:
+    - type: Transform
+      pos: 20.5,-32.5
+      parent: 1
+  - uid: 1222
+    components:
+    - type: Transform
+      pos: 21.5,-32.5
+      parent: 1
+  - uid: 1223
+    components:
+    - type: Transform
+      pos: 22.5,-32.5
+      parent: 1
+  - uid: 1224
+    components:
+    - type: Transform
+      pos: 21.5,-31.5
+      parent: 1
+  - uid: 1225
+    components:
+    - type: Transform
+      pos: 21.5,-29.5
+      parent: 1
+  - uid: 1226
+    components:
+    - type: Transform
+      pos: 21.5,-28.5
+      parent: 1
+  - uid: 1227
+    components:
+    - type: Transform
+      pos: 22.5,-28.5
+      parent: 1
+  - uid: 1228
+    components:
+    - type: Transform
+      pos: 20.5,-28.5
+      parent: 1
+  - uid: 1229
+    components:
+    - type: Transform
+      pos: 19.5,-28.5
+      parent: 1
+  - uid: 1230
+    components:
+    - type: Transform
+      pos: 19.5,-27.5
+      parent: 1
+  - uid: 1231
+    components:
+    - type: Transform
+      pos: 19.5,-26.5
+      parent: 1
+  - uid: 1232
+    components:
+    - type: Transform
+      pos: 19.5,-25.5
+      parent: 1
+  - uid: 1233
+    components:
+    - type: Transform
+      pos: 13.5,-29.5
+      parent: 1
+  - uid: 1234
+    components:
+    - type: Transform
+      pos: 12.5,-28.5
+      parent: 1
+  - uid: 1235
+    components:
+    - type: Transform
+      pos: 13.5,-28.5
+      parent: 1
+  - uid: 1236
+    components:
+    - type: Transform
+      pos: 14.5,-28.5
+      parent: 1
+  - uid: 1237
+    components:
+    - type: Transform
+      pos: 15.5,-28.5
+      parent: 1
+  - uid: 1238
+    components:
+    - type: Transform
+      pos: 15.5,-27.5
+      parent: 1
+  - uid: 1239
+    components:
+    - type: Transform
+      pos: 15.5,-26.5
+      parent: 1
+  - uid: 1240
+    components:
+    - type: Transform
+      pos: 15.5,-25.5
+      parent: 1
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: 18.5,-21.5
+      parent: 1
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: 19.5,-21.5
+      parent: 1
+  - uid: 1269
+    components:
+    - type: Transform
+      pos: 19.5,-22.5
+      parent: 1
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: 17.5,-39.5
+      parent: 1
+  - uid: 1274
+    components:
+    - type: Transform
+      pos: 17.5,-40.5
+      parent: 1
+  - uid: 1275
+    components:
+    - type: Transform
+      pos: 17.5,-41.5
+      parent: 1
+  - uid: 1276
+    components:
+    - type: Transform
+      pos: 18.5,-41.5
+      parent: 1
+  - uid: 1277
+    components:
+    - type: Transform
+      pos: 19.5,-41.5
+      parent: 1
+  - uid: 1278
+    components:
+    - type: Transform
+      pos: 21.5,-41.5
+      parent: 1
+  - uid: 1279
+    components:
+    - type: Transform
+      pos: 22.5,-41.5
+      parent: 1
+  - uid: 1280
+    components:
+    - type: Transform
+      pos: 23.5,-41.5
+      parent: 1
+  - uid: 1281
+    components:
+    - type: Transform
+      pos: 24.5,-41.5
+      parent: 1
+  - uid: 1282
+    components:
+    - type: Transform
+      pos: 25.5,-41.5
+      parent: 1
+  - uid: 1283
+    components:
+    - type: Transform
+      pos: 26.5,-41.5
+      parent: 1
+  - uid: 1284
+    components:
+    - type: Transform
+      pos: 27.5,-41.5
+      parent: 1
+  - uid: 1285
+    components:
+    - type: Transform
+      pos: 29.5,-41.5
+      parent: 1
+  - uid: 1286
+    components:
+    - type: Transform
+      pos: 20.5,-41.5
+      parent: 1
+  - uid: 1287
+    components:
+    - type: Transform
+      pos: 30.5,-41.5
+      parent: 1
+  - uid: 1288
+    components:
+    - type: Transform
+      pos: 28.5,-41.5
+      parent: 1
+  - uid: 1289
+    components:
+    - type: Transform
+      pos: 30.5,-40.5
+      parent: 1
+  - uid: 1290
+    components:
+    - type: Transform
+      pos: 30.5,-42.5
+      parent: 1
+  - uid: 1291
+    components:
+    - type: Transform
+      pos: 13.5,-20.5
+      parent: 1
+  - uid: 1292
+    components:
+    - type: Transform
+      pos: 12.5,-20.5
+      parent: 1
+  - uid: 1293
+    components:
+    - type: Transform
+      pos: 10.5,-20.5
+      parent: 1
+  - uid: 1294
+    components:
+    - type: Transform
+      pos: 9.5,-20.5
+      parent: 1
+  - uid: 1295
+    components:
+    - type: Transform
+      pos: 11.5,-20.5
+      parent: 1
+  - uid: 1296
+    components:
+    - type: Transform
+      pos: 9.5,-19.5
+      parent: 1
+  - uid: 1297
+    components:
+    - type: Transform
+      pos: 8.5,-19.5
+      parent: 1
+  - uid: 1298
+    components:
+    - type: Transform
+      pos: 6.5,-19.5
+      parent: 1
+  - uid: 1299
+    components:
+    - type: Transform
+      pos: 5.5,-19.5
+      parent: 1
+  - uid: 1300
+    components:
+    - type: Transform
+      pos: 4.5,-19.5
+      parent: 1
+  - uid: 1301
+    components:
+    - type: Transform
+      pos: 7.5,-19.5
+      parent: 1
+  - uid: 1302
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 1
+  - uid: 1303
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 1
+  - uid: 1304
+    components:
+    - type: Transform
+      pos: 27.5,-26.5
+      parent: 1
+  - uid: 1305
+    components:
+    - type: Transform
+      pos: 27.5,-25.5
+      parent: 1
+  - uid: 1306
+    components:
+    - type: Transform
+      pos: 27.5,-23.5
+      parent: 1
+  - uid: 1307
+    components:
+    - type: Transform
+      pos: 27.5,-22.5
+      parent: 1
+  - uid: 1308
+    components:
+    - type: Transform
+      pos: 27.5,-24.5
+      parent: 1
+  - uid: 1309
+    components:
+    - type: Transform
+      pos: 28.5,-22.5
+      parent: 1
+  - uid: 1310
+    components:
+    - type: Transform
+      pos: 28.5,-21.5
+      parent: 1
+  - uid: 1311
+    components:
+    - type: Transform
+      pos: 28.5,-19.5
+      parent: 1
+  - uid: 1312
+    components:
+    - type: Transform
+      pos: 28.5,-18.5
+      parent: 1
+  - uid: 1313
+    components:
+    - type: Transform
+      pos: 28.5,-17.5
+      parent: 1
+  - uid: 1314
+    components:
+    - type: Transform
+      pos: 28.5,-20.5
+      parent: 1
+  - uid: 1315
+    components:
+    - type: Transform
+      pos: 27.5,-17.5
+      parent: 1
+  - uid: 1316
+    components:
+    - type: Transform
+      pos: 29.5,-17.5
+      parent: 1
+  - uid: 1318
+    components:
+    - type: Transform
+      pos: 8.5,-30.5
+      parent: 1
+  - uid: 1319
+    components:
+    - type: Transform
+      pos: 7.5,-30.5
+      parent: 1
+  - uid: 1320
+    components:
+    - type: Transform
+      pos: 6.5,-30.5
+      parent: 1
+  - uid: 1321
+    components:
+    - type: Transform
+      pos: 6.5,-31.5
+      parent: 1
+  - uid: 1322
+    components:
+    - type: Transform
+      pos: 6.5,-32.5
+      parent: 1
+  - uid: 1323
+    components:
+    - type: Transform
+      pos: 6.5,-34.5
+      parent: 1
+  - uid: 1324
+    components:
+    - type: Transform
+      pos: 6.5,-35.5
+      parent: 1
+  - uid: 1325
+    components:
+    - type: Transform
+      pos: 6.5,-36.5
+      parent: 1
+  - uid: 1326
+    components:
+    - type: Transform
+      pos: 6.5,-37.5
+      parent: 1
+  - uid: 1327
+    components:
+    - type: Transform
+      pos: 6.5,-38.5
+      parent: 1
+  - uid: 1328
+    components:
+    - type: Transform
+      pos: 6.5,-33.5
+      parent: 1
+  - uid: 1329
+    components:
+    - type: Transform
+      pos: 6.5,-40.5
+      parent: 1
+  - uid: 1330
+    components:
+    - type: Transform
+      pos: 6.5,-42.5
+      parent: 1
+  - uid: 1331
+    components:
+    - type: Transform
+      pos: 6.5,-43.5
+      parent: 1
+  - uid: 1332
+    components:
+    - type: Transform
+      pos: 6.5,-39.5
+      parent: 1
+  - uid: 1333
+    components:
+    - type: Transform
+      pos: 6.5,-41.5
+      parent: 1
+  - uid: 1334
+    components:
+    - type: Transform
+      pos: 7.5,-43.5
+      parent: 1
+  - uid: 1335
+    components:
+    - type: Transform
+      pos: 5.5,-43.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 339
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-30.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-30.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-30.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 342
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-22.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-21.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-22.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-22.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-22.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-22.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-22.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-22.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-22.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-22.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-22.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-22.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-33.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-27.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-27.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-27.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-27.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-27.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-27.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-27.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-27.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-27.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-27.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-27.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-38.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-28.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-29.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-31.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-32.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-33.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-34.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-35.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-30.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-36.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-39.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-37.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-40.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-41.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-42.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-44.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-43.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-44.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-44.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-44.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-43.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-41.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-40.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-39.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-38.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-37.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-36.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-35.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-34.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-42.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-34.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-36.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-37.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-38.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-35.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-40.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-42.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-41.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-43.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-44.5
+      parent: 1
+  - uid: 406
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-39.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-44.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-44.5
+      parent: 1
+  - uid: 409
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-44.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-44.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-44.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-44.5
+      parent: 1
+  - uid: 413
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-44.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-44.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-44.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-44.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-44.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-44.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-44.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-44.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-44.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-44.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-44.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-43.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-39.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-38.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-38.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-38.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-38.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-38.5
+      parent: 1
+  - uid: 431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-38.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-38.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-38.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-38.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-38.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-38.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-33.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-33.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-33.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-33.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-33.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-33.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-33.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-33.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-33.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-33.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-19.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-32.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-31.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-30.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-28.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-27.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-26.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-29.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-25.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-24.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-23.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-22.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-20.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-21.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-16.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-17.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 31.5,-18.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 30.5,-16.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-16.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-16.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-18.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-17.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-20.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-21.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-23.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-22.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-24.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-25.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-26.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-19.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-26.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-24.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-23.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-22.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-21.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-20.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-18.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-17.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-16.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-25.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-19.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-16.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-16.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-16.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-16.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-16.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-16.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-16.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-16.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-16.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-16.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-16.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-16.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-17.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-33.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-30.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-32.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-30.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-30.5
+      parent: 1
+  - uid: 506
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-31.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-30.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-34.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-30.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-37.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-17.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-17.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-17.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-35.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-38.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-36.5
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 517
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.544292,-30.348793
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.474762,-27.369614
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.54614,-30.35116
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.452599,-34.37114
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 521
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-30.5
+      parent: 1
+- proto: ClothingBackpackDuffelSyndicateC4tBundle
+  entities:
+  - uid: 522
+    components:
+    - type: Transform
+      pos: 23.456856,-42.296715
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+    - type: GroupExamine
+      group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: >-
+            It provides the following protection:
+
+            - [color=orange]Explosion[/color] damage [color=white]to contents[/color] reduced by [color=lightblue]90%[/color].
+          priority: 0
+          component: Armor
+        - message: This decreases your running speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        title: null
+- proto: ClothingBackpackDuffelSyndicateFilledMedical
+  entities:
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 24.484493,-31.305508
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+- proto: ComputerIFFSyndicate
+  entities:
+  - uid: 524
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-34.5
+      parent: 1
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 13.5,-29.5
+      parent: 1
+- proto: ComputerRadar
+  entities:
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 21.5,-29.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-20.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.5,-42.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-40.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-20.5
+      parent: 1
+- proto: ComputerShuttleSyndie
+  entities:
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 17.5,-29.5
+      parent: 1
+- proto: DisposalBend
+  entities:
+  - uid: 532
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-22.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-22.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-30.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-38.5
+      parent: 1
+- proto: DisposalJunction
+  entities:
+  - uid: 536
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-30.5
+      parent: 1
+- proto: DisposalJunctionFlipped
+  entities:
+  - uid: 537
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-22.5
+      parent: 1
+  - uid: 538
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-25.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 539
+    components:
+    - type: Transform
+      pos: 20.5,-16.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 20.5,-17.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 20.5,-18.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: 20.5,-19.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: 20.5,-20.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: 20.5,-21.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-22.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: 17.5,-23.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: 17.5,-24.5
+      parent: 1
+  - uid: 548
+    components:
+    - type: Transform
+      pos: 17.5,-26.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      pos: 17.5,-27.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 17.5,-28.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 17.5,-29.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-30.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-30.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-30.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-30.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,-30.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-30.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: 17.5,-31.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 17.5,-32.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 17.5,-33.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: 17.5,-34.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      pos: 17.5,-35.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 17.5,-36.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 17.5,-37.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 565
+    components:
+    - type: Transform
+      pos: 18.5,-21.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-25.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: Transform
+      pos: 24.5,-29.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-38.5
+      parent: 1
+- proto: DisposalUnit
+  entities:
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 18.5,-21.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 18.5,-38.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 16.5,-25.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: 24.5,-29.5
+      parent: 1
+- proto: DoubleEmergencyOxygenTankFilled
+  entities:
+  - uid: 573
+    components:
+    - type: Transform
+      pos: 10.666044,-20.557781
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: 10.416044,-20.354656
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: 10.697294,-18.495281
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: 10.384794,-18.292156
+      parent: 1
+- proto: ExplosivesSignMed
+  entities:
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 26.5,-40.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 5.5,-39.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      pos: 8.5,-18.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      pos: 29.5,-21.5
+      parent: 1
+- proto: FaxMachineSyndie
+  entities:
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 16.5,-37.5
+      parent: 1
+- proto: GasMinerNitrogen
+  entities:
+  - uid: 581
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-38.5
+      parent: 1
+- proto: GasMinerOxygen
+  entities:
+  - uid: 582
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-36.5
+      parent: 1
+- proto: GasMixer
+  entities:
+  - uid: 583
+    components:
+    - type: MetaData
+      name: O2+N2 mixer
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-35.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.22000003
+      inletOneConcentration: 0.78
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasOutletInjector
+  entities:
+  - uid: 584
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-21.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 585
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 586
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-37.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 587
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 17.5,-20.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 589
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 590
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-42.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeBend
+  entities:
+  - uid: 591
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 592
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-37.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 593
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 594
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-29.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 595
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-29.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 596
+    components:
+    - type: Transform
+      pos: 17.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 15.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 598
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 599
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 600
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 601
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 602
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-37.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 603
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 5.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 605
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-33.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 606
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-34.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 607
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 608
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-36.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 609
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 610
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 611
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 612
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 613
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 614
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-29.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 615
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-28.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 616
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-27.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 618
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 619
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-24.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-23.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 621
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-22.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 17.5,-21.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 624
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 625
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 627
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 628
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 629
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 630
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 631
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 24.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 632
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 633
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 634
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 635
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 636
+    components:
+    - type: Transform
+      pos: 17.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 637
+    components:
+    - type: Transform
+      pos: 17.5,-33.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 638
+    components:
+    - type: Transform
+      pos: 17.5,-34.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 639
+    components:
+    - type: Transform
+      pos: 17.5,-35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 640
+    components:
+    - type: Transform
+      pos: 17.5,-36.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 641
+    components:
+    - type: Transform
+      pos: 17.5,-37.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 642
+    components:
+    - type: Transform
+      pos: 17.5,-38.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 643
+    components:
+    - type: Transform
+      pos: 17.5,-39.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 644
+    components:
+    - type: Transform
+      pos: 17.5,-40.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 645
+    components:
+    - type: Transform
+      pos: 17.5,-41.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-21.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 647
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-22.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 648
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-23.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 649
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-24.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 650
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-25.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 18.5,-27.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 652
+    components:
+    - type: Transform
+      pos: 18.5,-28.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 18.5,-29.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 654
+    components:
+    - type: Transform
+      pos: 18.5,-30.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 655
+    components:
+    - type: Transform
+      pos: 18.5,-33.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 656
+    components:
+    - type: Transform
+      pos: 18.5,-34.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 657
+    components:
+    - type: Transform
+      pos: 18.5,-35.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 658
+    components:
+    - type: Transform
+      pos: 18.5,-36.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 659
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 660
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 20.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 661
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 21.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 662
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 22.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 663
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 23.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 664
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 24.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 17.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 16.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 667
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 668
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 669
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 670
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 671
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 672
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 673
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 674
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 675
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-34.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 676
+    components:
+    - type: Transform
+      pos: 16.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 677
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-21.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 678
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 679
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 680
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPort
+  entities:
+  - uid: 681
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-34.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 682
+    components:
+    - type: Transform
+      pos: 18.5,-20.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 683
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 17.5,-26.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 684
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-37.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 685
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-31.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 686
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-32.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GeneratorRTG
+  entities:
+  - uid: 687
+    components:
+    - type: Transform
+      pos: 5.5,-32.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      pos: 7.5,-32.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      pos: 5.5,-33.5
+      parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      pos: 7.5,-33.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      pos: 5.5,-34.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 692
+    components:
+    - type: Transform
+      pos: 5.5,-36.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 693
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-27.5
+      parent: 1
+  - uid: 694
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-27.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-27.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-28.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-24.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      pos: 30.5,-42.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 23.5,-27.5
+      parent: 1
+  - uid: 700
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-27.5
+      parent: 1
+  - uid: 701
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-33.5
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-35.5
+      parent: 1
+  - uid: 703
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-37.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-36.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-34.5
+      parent: 1
+  - uid: 706
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-33.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-33.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-33.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-33.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-27.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-33.5
+      parent: 1
+  - uid: 712
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-33.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-25.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-22.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-26.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-23.5
+      parent: 1
+  - uid: 717
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-27.5
+      parent: 1
+  - uid: 718
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-27.5
+      parent: 1
+  - uid: 719
+    components:
+    - type: Transform
+      pos: 29.5,-17.5
+      parent: 1
+  - uid: 720
+    components:
+    - type: Transform
+      pos: 27.5,-17.5
+      parent: 1
+  - uid: 721
+    components:
+    - type: Transform
+      pos: 7.5,-43.5
+      parent: 1
+  - uid: 722
+    components:
+    - type: Transform
+      pos: 30.5,-40.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-28.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-25.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-26.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-38.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-25.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-28.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-27.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-26.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-28.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-28.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-28.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-32.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-32.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-32.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-33.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-35.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-34.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-33.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-35.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-34.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-32.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-32.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-32.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-22.5
+      parent: 1
+  - uid: 747
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-21.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 5.5,-43.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 751
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-32.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-28.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-28.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: 19.5,-32.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 755
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-29.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-31.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-31.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-31.5
+      parent: 1
+- proto: HospitalCurtains
+  entities:
+  - uid: 759
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-31.5
+      parent: 1
+- proto: LockerSyndicatePersonal
+  entities:
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 5.5,-40.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 761
+          - 762
+          - 765
+          - 763
+          - 764
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 766
+    components:
+    - type: Transform
+      pos: 7.5,-18.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 769
+          - 767
+          - 770
+          - 768
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 771
+    components:
+    - type: Transform
+      pos: 29.5,-20.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 773
+          - 775
+          - 772
+          - 776
+          - 774
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 777
+    components:
+    - type: Transform
+      pos: 27.5,-40.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 780
+          - 781
+          - 778
+          - 779
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: LockerSyndicatePersonalFilled
+  entities:
+  - uid: 782
+    components:
+    - type: Transform
+      pos: 19.5,-40.5
+      parent: 1
+  - uid: 783
+    components:
+    - type: Transform
+      pos: 21.5,-40.5
+      parent: 1
+  - uid: 784
+    components:
+    - type: Transform
+      pos: 23.5,-40.5
+      parent: 1
+  - uid: 785
+    components:
+    - type: Transform
+      pos: 25.5,-40.5
+      parent: 1
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 20.5,-42.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 22.5,-42.5
+      parent: 1
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 24.5,-42.5
+      parent: 1
+- proto: LockerSyndicateShipGearBasic
+  entities:
+  - uid: 789
+    components:
+    - type: Transform
+      pos: 16.5,-42.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 793
+          - 792
+          - 791
+          - 790
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 794
+    components:
+    - type: Transform
+      pos: 16.5,-41.5
+      parent: 1
+  - uid: 795
+    components:
+    - type: Transform
+      pos: 16.5,-40.5
+      parent: 1
+  - uid: 796
+    components:
+    - type: Transform
+      pos: 14.5,-18.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: MagazineGrenadeBlast
+  entities:
+  - uid: 761
+    components:
+    - type: Transform
+      parent: 760
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 762
+    components:
+    - type: Transform
+      parent: 760
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 767
+    components:
+    - type: Transform
+      parent: 766
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 768
+    components:
+    - type: Transform
+      parent: 766
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 772
+    components:
+    - type: Transform
+      parent: 771
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 773
+    components:
+    - type: Transform
+      parent: 771
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 778
+    components:
+    - type: Transform
+      parent: 777
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 779
+    components:
+    - type: Transform
+      parent: 777
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 797
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.506939,-40.374687
+      parent: 1
+  - uid: 798
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.506939,-40.577812
+      parent: 1
+  - uid: 799
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.522564,-40.374687
+      parent: 1
+  - uid: 800
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.585064,-40.312187
+      parent: 1
+  - uid: 801
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.538189,-40.343437
+      parent: 1
+- proto: MagazineGrenadeFrag
+  entities:
+  - uid: 763
+    components:
+    - type: Transform
+      parent: 760
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 764
+    components:
+    - type: Transform
+      parent: 760
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 769
+    components:
+    - type: Transform
+      parent: 766
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 770
+    components:
+    - type: Transform
+      parent: 766
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 774
+    components:
+    - type: Transform
+      parent: 771
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 775
+    components:
+    - type: Transform
+      parent: 771
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 780
+    components:
+    - type: Transform
+      parent: 777
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 781
+    components:
+    - type: Transform
+      parent: 777
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 802
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.527748,-40.499687
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.537952,-40.249687
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.475452,-40.624687
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 806
+    components:
+    - type: Transform
+      pos: 29.5,-26.5
+      parent: 1
+  - uid: 807
+    components:
+    - type: Transform
+      pos: 29.5,-28.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      pos: 27.5,-24.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      pos: 27.5,-26.5
+      parent: 1
+  - uid: 810
+    components:
+    - type: Transform
+      pos: 27.5,-28.5
+      parent: 1
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 811
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.487244,-30.664253
+      parent: 1
+  - uid: 812
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.502869,-30.289253
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 813
+    components:
+    - type: Transform
+      pos: 29.745197,-31.537388
+      parent: 1
+  - uid: 814
+    components:
+    - type: Transform
+      pos: 29.745197,-31.162388
+      parent: 1
+- proto: MedkitBurnFilled
+  entities:
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.7113,-31.619728
+      parent: 1
+  - uid: 816
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.6488,-31.275978
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 817
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.539528,-31.261126
+      parent: 1
+  - uid: 818
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 27.523903,-31.542376
+      parent: 1
+  - uid: 819
+    components:
+    - type: Transform
+      pos: 25.569118,-29.292492
+      parent: 1
+  - uid: 820
+    components:
+    - type: Transform
+      pos: 26.475368,-29.323742
+      parent: 1
+- proto: MedkitFilled
+  entities:
+  - uid: 821
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.311817,-31.198626
+      parent: 1
+  - uid: 822
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.327442,-31.558
+      parent: 1
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 823
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.19524,-31.553284
+      parent: 1
+  - uid: 824
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 29.16399,-31.162659
+      parent: 1
+- proto: NuclearBombUnanchored
+  entities:
+  - uid: 825
+    components:
+    - type: Transform
+      pos: 16.5,-38.5
+      parent: 1
+- proto: OperatingTable
+  entities:
+  - uid: 826
+    components:
+    - type: Transform
+      pos: 25.5,-31.5
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-37.5
+      parent: 1
+  - uid: 828
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-38.5
+      parent: 1
+  - uid: 829
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-36.5
+      parent: 1
+  - uid: 830
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-35.5
+      parent: 1
+  - uid: 831
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-35.5
+      parent: 1
+  - uid: 832
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-37.5
+      parent: 1
+- proto: PlastitaniumWindow
+  entities:
+  - uid: 833
+    components:
+    - type: Transform
+      pos: 19.5,-34.5
+      parent: 1
+  - uid: 834
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-34.5
+      parent: 1
+  - uid: 835
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-27.5
+      parent: 1
+  - uid: 836
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-28.5
+      parent: 1
+  - uid: 837
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-25.5
+      parent: 1
+  - uid: 838
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-33.5
+      parent: 1
+  - uid: 839
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-32.5
+      parent: 1
+  - uid: 840
+    components:
+    - type: Transform
+      pos: 4.5,-18.5
+      parent: 1
+  - uid: 841
+    components:
+    - type: Transform
+      pos: 5.5,-43.5
+      parent: 1
+  - uid: 842
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-28.5
+      parent: 1
+  - uid: 843
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-26.5
+      parent: 1
+  - uid: 844
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-32.5
+      parent: 1
+  - uid: 845
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-32.5
+      parent: 1
+  - uid: 846
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 21.5,-28.5
+      parent: 1
+  - uid: 847
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-27.5
+      parent: 1
+  - uid: 848
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-25.5
+      parent: 1
+  - uid: 849
+    components:
+    - type: Transform
+      pos: 4.5,-20.5
+      parent: 1
+  - uid: 850
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-22.5
+      parent: 1
+  - uid: 851
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-32.5
+      parent: 1
+  - uid: 852
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-21.5
+      parent: 1
+  - uid: 853
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-32.5
+      parent: 1
+  - uid: 854
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-35.5
+      parent: 1
+  - uid: 855
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.5,-26.5
+      parent: 1
+  - uid: 856
+    components:
+    - type: Transform
+      pos: 30.5,-42.5
+      parent: 1
+  - uid: 857
+    components:
+    - type: Transform
+      pos: 19.5,-33.5
+      parent: 1
+  - uid: 858
+    components:
+    - type: Transform
+      pos: 19.5,-35.5
+      parent: 1
+  - uid: 859
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-28.5
+      parent: 1
+  - uid: 860
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-28.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 12.5,-32.5
+      parent: 1
+  - uid: 862
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 13.5,-28.5
+      parent: 1
+  - uid: 863
+    components:
+    - type: Transform
+      pos: 30.5,-40.5
+      parent: 1
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 29.5,-17.5
+      parent: 1
+  - uid: 865
+    components:
+    - type: Transform
+      pos: 7.5,-43.5
+      parent: 1
+  - uid: 866
+    components:
+    - type: Transform
+      pos: 27.5,-17.5
+      parent: 1
+- proto: PlastitaniumWindowDiagonal
+  entities:
+  - uid: 867
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-28.5
+      parent: 1
+  - uid: 868
+    components:
+    - type: Transform
+      pos: 19.5,-32.5
+      parent: 1
+  - uid: 869
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-28.5
+      parent: 1
+  - uid: 870
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,-32.5
+      parent: 1
+- proto: PosterContrabandC20r
+  entities:
+  - uid: 871
+    components:
+    - type: Transform
+      pos: 26.5,-42.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 872
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-18.5
+      parent: 1
+  - uid: 873
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-20.5
+      parent: 1
+  - uid: 874
+    components:
+    - type: Transform
+      pos: 10.5,-18.5
+      parent: 1
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-20.5
+      parent: 1
+  - uid: 876
+    components:
+    - type: Transform
+      pos: 14.5,-18.5
+      parent: 1
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,-20.5
+      parent: 1
+  - uid: 878
+    components:
+    - type: Transform
+      pos: 18.5,-25.5
+      parent: 1
+  - uid: 879
+    components:
+    - type: Transform
+      pos: 16.5,-25.5
+      parent: 1
+  - uid: 880
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.5,-35.5
+      parent: 1
+  - uid: 881
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-35.5
+      parent: 1
+  - uid: 882
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-31.5
+      parent: 1
+  - uid: 883
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 22.5,-29.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-29.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,-31.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      pos: 20.5,-40.5
+      parent: 1
+  - uid: 887
+    components:
+    - type: Transform
+      pos: 24.5,-40.5
+      parent: 1
+  - uid: 888
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-42.5
+      parent: 1
+  - uid: 889
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.5,-42.5
+      parent: 1
+  - uid: 890
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-39.5
+      parent: 1
+  - uid: 891
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-37.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-23.5
+      parent: 1
+  - uid: 893
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-23.5
+      parent: 1
+  - uid: 894
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-31.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-31.5
+      parent: 1
+  - uid: 896
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-30.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      pos: 25.5,-29.5
+      parent: 1
+  - uid: 898
+    components:
+    - type: Transform
+      pos: 26.5,-29.5
+      parent: 1
+- proto: PoweredlightExterior
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-39.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 16.5,-44.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 26.5,-43.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-38.5
+      parent: 1
+  - uid: 1191
+    components:
+    - type: Transform
+      pos: 26.5,-33.5
+      parent: 1
+  - uid: 1192
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 25.5,-21.5
+      parent: 1
+  - uid: 1193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-27.5
+      parent: 1
+  - uid: 1194
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-21.5
+      parent: 1
+  - uid: 1195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 30.5,-16.5
+      parent: 1
+  - uid: 1196
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-27.5
+      parent: 1
+  - uid: 1197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-16.5
+      parent: 1
+  - uid: 1198
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-16.5
+      parent: 1
+  - uid: 1199
+    components:
+    - type: Transform
+      pos: 8.5,-22.5
+      parent: 1
+  - uid: 1200
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-21.5
+      parent: 1
+  - uid: 1201
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-31.5
+      parent: 1
+  - uid: 1202
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-39.5
+      parent: 1
+  - uid: 1203
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-39.5
+      parent: 1
+  - uid: 1204
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,-39.5
+      parent: 1
+  - uid: 1205
+    components:
+    - type: Transform
+      pos: 8.5,-44.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 899
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-30.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-36.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-19.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-41.5
+      parent: 1
+  - uid: 903
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-20.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-42.5
+      parent: 1
+  - uid: 905
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-17.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-17.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 907
+    components:
+    - type: Transform
+      pos: 25.5,-42.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      pos: 23.5,-42.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      pos: 19.5,-42.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      pos: 21.5,-42.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 20.5,-40.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-40.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-40.5
+      parent: 1
+- proto: RemoteSignallerAdvanced
+  entities:
+  - uid: 790
+    components:
+    - type: Transform
+      parent: 789
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 791
+    components:
+    - type: Transform
+      parent: 789
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 792
+    components:
+    - type: Transform
+      parent: 789
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 793
+    components:
+    - type: Transform
+      parent: 789
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ShuttleGunDuster
+  entities:
+  - uid: 914
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-19.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      pos: 6.5,-41.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-19.5
+      parent: 1
+    - type: DeviceLinkSink
+      invokeCounter: 1
+  - uid: 917
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 28.5,-41.5
+      parent: 1
+- proto: SignalButton
+  entities:
+  - uid: 918
+    components:
+    - type: MetaData
+      name: fire cannon
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 28.5,-20.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        916:
+        - Pressed: Trigger
+        45:
+        - Pressed: Open
+  - uid: 919
+    components:
+    - type: MetaData
+      name: fire cannon
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-19.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        914:
+        - Pressed: Trigger
+        46:
+        - Pressed: Open
+  - uid: 920
+    components:
+    - type: Transform
+      pos: 6.5,-40.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        915:
+        - Pressed: Trigger
+        44:
+        - Pressed: Open
+  - uid: 921
+    components:
+    - type: MetaData
+      name: fire top right cannon
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.251953,-30.535576
+      parent: 1
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        916:
+        - Pressed: Trigger
+        45:
+        - Pressed: Open
+  - uid: 922
+    components:
+    - type: MetaData
+      name: fire bottom right cannon
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.251953,-30.879326
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        917:
+        - Pressed: Trigger
+        47:
+        - Pressed: Open
+  - uid: 923
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-42.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        44:
+        - Pressed: Toggle
+  - uid: 924
+    components:
+    - type: MetaData
+      name: fire bottom left cannon
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 16.751953,-30.941826
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        915:
+        - Pressed: Trigger
+        44:
+        - Pressed: Open
+  - uid: 925
+    components:
+    - type: MetaData
+      name: toggle blast doors
+    - type: Transform
+      pos: 28.5,-39.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        47:
+        - Pressed: Toggle
+  - uid: 926
+    components:
+    - type: MetaData
+      name: fire top left cannon
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.44965,-30.256165
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        914:
+        - Pressed: Trigger
+        46:
+        - Pressed: Open
+  - uid: 927
+    components:
+    - type: MetaData
+      name: toggle blast doors
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 26.5,-19.5
+      parent: 1
+    - type: SignalSwitch
+      state: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        45:
+        - Pressed: Toggle
+  - uid: 928
+    components:
+    - type: MetaData
+      name: toggle blast doors
+    - type: Transform
+      pos: 6.5,-17.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        46:
+        - Pressed: Toggle
+  - uid: 929
+    components:
+    - type: MetaData
+      name: fire cannon
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-41.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        47:
+        - Pressed: Open
+        917:
+        - Pressed: Trigger
+  - uid: 930
+    components:
+    - type: MetaData
+      name: top right blast door
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.996964,-30.23375
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        45:
+        - Pressed: Toggle
+  - uid: 931
+    components:
+    - type: MetaData
+      name: bottom right blast door
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 19.012589,-30.593124
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        47:
+        - Pressed: Toggle
+  - uid: 932
+    components:
+    - type: MetaData
+      name: top left blast door
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.991015,-30.265
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        46:
+        - Pressed: Toggle
+  - uid: 933
+    components:
+    - type: MetaData
+      name: bottom left blast door
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.991015,-30.655624
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        44:
+        - Pressed: Toggle
+- proto: SignArmory
+  entities:
+  - uid: 934
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-36.5
+      parent: 1
+- proto: SignElectricalMed
+  entities:
+  - uid: 935
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 11.5,-29.5
+      parent: 1
+- proto: SignRadiationMed
+  entities:
+  - uid: 936
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-32.5
+      parent: 1
+  - uid: 937
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-33.5
+      parent: 1
+  - uid: 938
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-32.5
+      parent: 1
+  - uid: 939
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-33.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 940
+    components:
+    - type: Transform
+      pos: 5.5,-29.5
+      parent: 1
+  - uid: 941
+    components:
+    - type: Transform
+      pos: 7.5,-29.5
+      parent: 1
+  - uid: 942
+    components:
+    - type: Transform
+      pos: 6.5,-29.5
+      parent: 1
+- proto: StasisBed
+  entities:
+  - uid: 805
+    components:
+    - type: Transform
+      pos: 29.5,-24.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 943
+    components:
+    - type: Transform
+      pos: 9.5,-29.5
+      parent: 1
+  - uid: 944
+    components:
+    - type: Transform
+      pos: 9.5,-31.5
+      parent: 1
+  - uid: 945
+    components:
+    - type: Transform
+      pos: 10.5,-29.5
+      parent: 1
+  - uid: 946
+    components:
+    - type: Transform
+      pos: 10.5,-31.5
+      parent: 1
+- proto: SuitStorageEVASyndicate
+  entities:
+  - uid: 947
+    components:
+    - type: Transform
+      pos: 9.5,-20.5
+      parent: 1
+  - uid: 948
+    components:
+    - type: Transform
+      pos: 13.5,-18.5
+      parent: 1
+  - uid: 949
+    components:
+    - type: Transform
+      pos: 11.5,-18.5
+      parent: 1
+  - uid: 950
+    components:
+    - type: Transform
+      pos: 9.5,-18.5
+      parent: 1
+  - uid: 951
+    components:
+    - type: Transform
+      pos: 11.5,-20.5
+      parent: 1
+  - uid: 952
+    components:
+    - type: Transform
+      pos: 13.5,-20.5
+      parent: 1
+- proto: SyndicateComputerComms
+  entities:
+  - uid: 953
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-27.5
+      parent: 1
+- proto: SyndieMiniBomb
+  entities:
+  - uid: 954
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.176712,-42.45495
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.457962,-42.470573
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 19.707962,-42.470573
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 957
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 18.5,-30.5
+      parent: 1
+  - uid: 958
+    components:
+    - type: MetaData
+      name: bottom left blast door
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-30.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      pos: 10.5,-18.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 10.5,-20.5
+      parent: 1
+  - uid: 961
+    components:
+    - type: Transform
+      pos: 16.5,-39.5
+      parent: 1
+  - uid: 962
+    components:
+    - type: Transform
+      pos: 16.5,-37.5
+      parent: 1
+- proto: TableReinforcedGlass
+  entities:
+  - uid: 963
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 26.5,-31.5
+      parent: 1
+  - uid: 964
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 28.5,-31.5
+      parent: 1
+  - uid: 965
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-31.5
+      parent: 1
+  - uid: 966
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-31.5
+      parent: 1
+  - uid: 967
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-30.5
+      parent: 1
+  - uid: 968
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-27.5
+      parent: 1
+  - uid: 969
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-27.5
+      parent: 1
+  - uid: 970
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 29.5,-25.5
+      parent: 1
+  - uid: 971
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 27.5,-25.5
+      parent: 1
+  - uid: 972
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 26.5,-29.5
+      parent: 1
+  - uid: 973
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-29.5
+      parent: 1
+  - uid: 974
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-31.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 975
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 13.5,-22.5
+      parent: 1
+  - uid: 976
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-37.5
+      parent: 1
+  - uid: 977
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-22.5
+      parent: 1
+  - uid: 978
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-36.5
+      parent: 1
+    - type: Thruster
+      enabled: False
+  - uid: 979
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 11.5,-22.5
+      parent: 1
+  - uid: 980
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-34.5
+      parent: 1
+    - type: Thruster
+      enabled: False
+  - uid: 981
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-35.5
+      parent: 1
+  - uid: 982
+    components:
+    - type: Transform
+      pos: 12.5,-27.5
+      parent: 1
+  - uid: 983
+    components:
+    - type: Transform
+      pos: 10.5,-27.5
+      parent: 1
+  - uid: 984
+    components:
+    - type: Transform
+      pos: 13.5,-27.5
+      parent: 1
+  - uid: 985
+    components:
+    - type: Transform
+      pos: 11.5,-27.5
+      parent: 1
+  - uid: 986
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 12.5,-22.5
+      parent: 1
+  - uid: 987
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-23.5
+      parent: 1
+  - uid: 988
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-25.5
+      parent: 1
+  - uid: 989
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-26.5
+      parent: 1
+  - uid: 990
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 20.5,-24.5
+      parent: 1
+  - uid: 991
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,-23.5
+      parent: 1
+  - uid: 992
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,-25.5
+      parent: 1
+  - uid: 993
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,-26.5
+      parent: 1
+  - uid: 994
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 25.5,-24.5
+      parent: 1
+  - uid: 995
+    components:
+    - type: Transform
+      pos: 21.5,-38.5
+      parent: 1
+  - uid: 996
+    components:
+    - type: Transform
+      pos: 23.5,-38.5
+      parent: 1
+  - uid: 997
+    components:
+    - type: Transform
+      pos: 24.5,-38.5
+      parent: 1
+  - uid: 998
+    components:
+    - type: Transform
+      pos: 22.5,-38.5
+      parent: 1
+  - uid: 999
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,-33.5
+      parent: 1
+  - uid: 1000
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,-33.5
+      parent: 1
+  - uid: 1001
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 24.5,-33.5
+      parent: 1
+  - uid: 1002
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-34.5
+      parent: 1
+  - uid: 1003
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 23.5,-33.5
+      parent: 1
+  - uid: 1004
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-36.5
+      parent: 1
+  - uid: 1005
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-37.5
+      parent: 1
+  - uid: 1006
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 14.5,-35.5
+      parent: 1
+- proto: ToolboxSyndicateFilled
+  entities:
+  - uid: 765
+    components:
+    - type: Transform
+      parent: 760
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 776
+    components:
+    - type: Transform
+      parent: 771
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1007
+    components:
+    - type: Transform
+      pos: 29.43509,-23.564476
+      parent: 1
+- proto: VendingMachineCigs
+  entities:
+  - uid: 1008
+    components:
+    - type: Transform
+      pos: 18.5,-42.5
+      parent: 1
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 1009
+    components:
+    - type: Transform
+      pos: 5.5,-38.5
+      parent: 1
+- proto: VendingMachineSustenance
+  entities:
+  - uid: 1010
+    components:
+    - type: Transform
+      pos: 29.5,-22.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 1011
+    components:
+    - type: Transform
+      pos: 12.5,-20.5
+      parent: 1
+  - uid: 1012
+    components:
+    - type: Transform
+      pos: 12.5,-18.5
+      parent: 1
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 1013
+    components:
+    - type: Transform
+      pos: 5.5,-37.5
+      parent: 1
+- proto: WallPlastitanium
+  entities:
+  - uid: 1014
+    components:
+    - type: Transform
+      pos: 4.5,-38.5
+      parent: 1
+  - uid: 1015
+    components:
+    - type: Transform
+      pos: 15.5,-23.5
+      parent: 1
+  - uid: 1016
+    components:
+    - type: Transform
+      pos: 18.5,-43.5
+      parent: 1
+  - uid: 1017
+    components:
+    - type: Transform
+      pos: 15.5,-38.5
+      parent: 1
+  - uid: 1018
+    components:
+    - type: Transform
+      pos: 15.5,-21.5
+      parent: 1
+  - uid: 1019
+    components:
+    - type: Transform
+      pos: 8.5,-33.5
+      parent: 1
+  - uid: 1020
+    components:
+    - type: Transform
+      pos: 8.5,-38.5
+      parent: 1
+  - uid: 1021
+    components:
+    - type: Transform
+      pos: 19.5,-43.5
+      parent: 1
+  - uid: 1022
+    components:
+    - type: Transform
+      pos: 9.5,-32.5
+      parent: 1
+  - uid: 1023
+    components:
+    - type: Transform
+      pos: 4.5,-33.5
+      parent: 1
+  - uid: 1024
+    components:
+    - type: Transform
+      pos: 4.5,-42.5
+      parent: 1
+  - uid: 1025
+    components:
+    - type: Transform
+      pos: 15.5,-24.5
+      parent: 1
+  - uid: 1026
+    components:
+    - type: Transform
+      pos: 15.5,-22.5
+      parent: 1
+  - uid: 1027
+    components:
+    - type: Transform
+      pos: 16.5,-43.5
+      parent: 1
+  - uid: 1028
+    components:
+    - type: Transform
+      pos: 4.5,-29.5
+      parent: 1
+  - uid: 1029
+    components:
+    - type: Transform
+      pos: 4.5,-31.5
+      parent: 1
+  - uid: 1030
+    components:
+    - type: Transform
+      pos: 4.5,-32.5
+      parent: 1
+  - uid: 1031
+    components:
+    - type: Transform
+      pos: 8.5,-32.5
+      parent: 1
+  - uid: 1032
+    components:
+    - type: Transform
+      pos: 4.5,-36.5
+      parent: 1
+  - uid: 1033
+    components:
+    - type: Transform
+      pos: 4.5,-37.5
+      parent: 1
+  - uid: 1034
+    components:
+    - type: Transform
+      pos: 4.5,-30.5
+      parent: 1
+  - uid: 1035
+    components:
+    - type: Transform
+      pos: 19.5,-23.5
+      parent: 1
+  - uid: 1036
+    components:
+    - type: Transform
+      pos: 15.5,-36.5
+      parent: 1
+  - uid: 1037
+    components:
+    - type: Transform
+      pos: 4.5,-35.5
+      parent: 1
+  - uid: 1038
+    components:
+    - type: Transform
+      pos: 9.5,-28.5
+      parent: 1
+  - uid: 1039
+    components:
+    - type: Transform
+      pos: 19.5,-19.5
+      parent: 1
+  - uid: 1040
+    components:
+    - type: Transform
+      pos: 19.5,-18.5
+      parent: 1
+  - uid: 1041
+    components:
+    - type: Transform
+      pos: 19.5,-20.5
+      parent: 1
+  - uid: 1042
+    components:
+    - type: Transform
+      pos: 19.5,-17.5
+      parent: 1
+  - uid: 1043
+    components:
+    - type: Transform
+      pos: 10.5,-32.5
+      parent: 1
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: 19.5,-24.5
+      parent: 1
+  - uid: 1045
+    components:
+    - type: Transform
+      pos: 7.5,-28.5
+      parent: 1
+  - uid: 1046
+    components:
+    - type: Transform
+      pos: 8.5,-28.5
+      parent: 1
+  - uid: 1047
+    components:
+    - type: Transform
+      pos: 5.5,-28.5
+      parent: 1
+  - uid: 1048
+    components:
+    - type: Transform
+      pos: 10.5,-28.5
+      parent: 1
+  - uid: 1049
+    components:
+    - type: Transform
+      pos: 4.5,-17.5
+      parent: 1
+  - uid: 1050
+    components:
+    - type: Transform
+      pos: 6.5,-28.5
+      parent: 1
+  - uid: 1051
+    components:
+    - type: Transform
+      pos: 4.5,-28.5
+      parent: 1
+  - uid: 1052
+    components:
+    - type: Transform
+      pos: 8.5,-41.5
+      parent: 1
+  - uid: 1053
+    components:
+    - type: Transform
+      pos: 15.5,-40.5
+      parent: 1
+  - uid: 1054
+    components:
+    - type: Transform
+      pos: 15.5,-39.5
+      parent: 1
+  - uid: 1055
+    components:
+    - type: Transform
+      pos: 15.5,-41.5
+      parent: 1
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: 15.5,-42.5
+      parent: 1
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: 15.5,-43.5
+      parent: 1
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: 4.5,-39.5
+      parent: 1
+  - uid: 1059
+    components:
+    - type: Transform
+      pos: 4.5,-41.5
+      parent: 1
+  - uid: 1060
+    components:
+    - type: Transform
+      pos: 4.5,-43.5
+      parent: 1
+  - uid: 1061
+    components:
+    - type: Transform
+      pos: 4.5,-40.5
+      parent: 1
+  - uid: 1062
+    components:
+    - type: Transform
+      pos: 4.5,-34.5
+      parent: 1
+  - uid: 1063
+    components:
+    - type: Transform
+      pos: 8.5,-43.5
+      parent: 1
+  - uid: 1064
+    components:
+    - type: Transform
+      pos: 8.5,-42.5
+      parent: 1
+  - uid: 1065
+    components:
+    - type: Transform
+      pos: 8.5,-37.5
+      parent: 1
+  - uid: 1066
+    components:
+    - type: Transform
+      pos: 8.5,-36.5
+      parent: 1
+  - uid: 1067
+    components:
+    - type: Transform
+      pos: 8.5,-40.5
+      parent: 1
+  - uid: 1068
+    components:
+    - type: Transform
+      pos: 15.5,-37.5
+      parent: 1
+  - uid: 1069
+    components:
+    - type: Transform
+      pos: 23.5,-39.5
+      parent: 1
+  - uid: 1070
+    components:
+    - type: Transform
+      pos: 20.5,-39.5
+      parent: 1
+  - uid: 1071
+    components:
+    - type: Transform
+      pos: 19.5,-36.5
+      parent: 1
+  - uid: 1072
+    components:
+    - type: Transform
+      pos: 8.5,-34.5
+      parent: 1
+  - uid: 1073
+    components:
+    - type: Transform
+      pos: 19.5,-38.5
+      parent: 1
+  - uid: 1074
+    components:
+    - type: Transform
+      pos: 8.5,-39.5
+      parent: 1
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: 8.5,-35.5
+      parent: 1
+  - uid: 1076
+    components:
+    - type: Transform
+      pos: 17.5,-43.5
+      parent: 1
+  - uid: 1077
+    components:
+    - type: Transform
+      pos: 21.5,-39.5
+      parent: 1
+  - uid: 1078
+    components:
+    - type: Transform
+      pos: 19.5,-39.5
+      parent: 1
+  - uid: 1079
+    components:
+    - type: Transform
+      pos: 24.5,-39.5
+      parent: 1
+  - uid: 1080
+    components:
+    - type: Transform
+      pos: 26.5,-39.5
+      parent: 1
+  - uid: 1081
+    components:
+    - type: Transform
+      pos: 25.5,-39.5
+      parent: 1
+  - uid: 1082
+    components:
+    - type: Transform
+      pos: 28.5,-39.5
+      parent: 1
+  - uid: 1083
+    components:
+    - type: Transform
+      pos: 19.5,-37.5
+      parent: 1
+  - uid: 1084
+    components:
+    - type: Transform
+      pos: 27.5,-39.5
+      parent: 1
+  - uid: 1085
+    components:
+    - type: Transform
+      pos: 22.5,-39.5
+      parent: 1
+  - uid: 1086
+    components:
+    - type: Transform
+      pos: 29.5,-39.5
+      parent: 1
+  - uid: 1087
+    components:
+    - type: Transform
+      pos: 30.5,-39.5
+      parent: 1
+  - uid: 1088
+    components:
+    - type: Transform
+      pos: 30.5,-43.5
+      parent: 1
+  - uid: 1089
+    components:
+    - type: Transform
+      pos: 29.5,-43.5
+      parent: 1
+  - uid: 1090
+    components:
+    - type: Transform
+      pos: 27.5,-43.5
+      parent: 1
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: 26.5,-43.5
+      parent: 1
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: 25.5,-43.5
+      parent: 1
+  - uid: 1093
+    components:
+    - type: Transform
+      pos: 24.5,-43.5
+      parent: 1
+  - uid: 1094
+    components:
+    - type: Transform
+      pos: 23.5,-43.5
+      parent: 1
+  - uid: 1095
+    components:
+    - type: Transform
+      pos: 22.5,-43.5
+      parent: 1
+  - uid: 1096
+    components:
+    - type: Transform
+      pos: 20.5,-43.5
+      parent: 1
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: 28.5,-43.5
+      parent: 1
+  - uid: 1098
+    components:
+    - type: Transform
+      pos: 21.5,-43.5
+      parent: 1
+  - uid: 1099
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-28.5
+      parent: 1
+  - uid: 1100
+    components:
+    - type: Transform
+      pos: 23.5,-32.5
+      parent: 1
+  - uid: 1101
+    components:
+    - type: Transform
+      pos: 24.5,-32.5
+      parent: 1
+  - uid: 1102
+    components:
+    - type: Transform
+      pos: 25.5,-32.5
+      parent: 1
+  - uid: 1103
+    components:
+    - type: Transform
+      pos: 26.5,-32.5
+      parent: 1
+  - uid: 1104
+    components:
+    - type: Transform
+      pos: 28.5,-32.5
+      parent: 1
+  - uid: 1105
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 11.5,-32.5
+      parent: 1
+  - uid: 1106
+    components:
+    - type: Transform
+      pos: 29.5,-32.5
+      parent: 1
+  - uid: 1107
+    components:
+    - type: Transform
+      pos: 30.5,-32.5
+      parent: 1
+  - uid: 1108
+    components:
+    - type: Transform
+      pos: 27.5,-32.5
+      parent: 1
+  - uid: 1109
+    components:
+    - type: Transform
+      pos: 24.5,-28.5
+      parent: 1
+  - uid: 1110
+    components:
+    - type: Transform
+      pos: 25.5,-28.5
+      parent: 1
+  - uid: 1111
+    components:
+    - type: Transform
+      pos: 26.5,-28.5
+      parent: 1
+  - uid: 1112
+    components:
+    - type: Transform
+      pos: 23.5,-28.5
+      parent: 1
+  - uid: 1113
+    components:
+    - type: Transform
+      pos: 30.5,-31.5
+      parent: 1
+  - uid: 1114
+    components:
+    - type: Transform
+      pos: 30.5,-29.5
+      parent: 1
+  - uid: 1115
+    components:
+    - type: Transform
+      pos: 30.5,-28.5
+      parent: 1
+  - uid: 1116
+    components:
+    - type: Transform
+      pos: 30.5,-30.5
+      parent: 1
+  - uid: 1117
+    components:
+    - type: Transform
+      pos: 30.5,-27.5
+      parent: 1
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: 30.5,-25.5
+      parent: 1
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: 30.5,-24.5
+      parent: 1
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: 30.5,-23.5
+      parent: 1
+  - uid: 1121
+    components:
+    - type: Transform
+      pos: 30.5,-22.5
+      parent: 1
+  - uid: 1122
+    components:
+    - type: Transform
+      pos: 30.5,-20.5
+      parent: 1
+  - uid: 1123
+    components:
+    - type: Transform
+      pos: 30.5,-26.5
+      parent: 1
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: 30.5,-19.5
+      parent: 1
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: 30.5,-18.5
+      parent: 1
+  - uid: 1126
+    components:
+    - type: Transform
+      pos: 30.5,-21.5
+      parent: 1
+  - uid: 1127
+    components:
+    - type: Transform
+      pos: 30.5,-17.5
+      parent: 1
+  - uid: 1128
+    components:
+    - type: Transform
+      pos: 26.5,-17.5
+      parent: 1
+  - uid: 1129
+    components:
+    - type: Transform
+      pos: 26.5,-18.5
+      parent: 1
+  - uid: 1130
+    components:
+    - type: Transform
+      pos: 26.5,-20.5
+      parent: 1
+  - uid: 1131
+    components:
+    - type: Transform
+      pos: 26.5,-21.5
+      parent: 1
+  - uid: 1132
+    components:
+    - type: Transform
+      pos: 26.5,-22.5
+      parent: 1
+  - uid: 1133
+    components:
+    - type: Transform
+      pos: 26.5,-23.5
+      parent: 1
+  - uid: 1134
+    components:
+    - type: Transform
+      pos: 26.5,-24.5
+      parent: 1
+  - uid: 1135
+    components:
+    - type: Transform
+      pos: 26.5,-25.5
+      parent: 1
+  - uid: 1136
+    components:
+    - type: Transform
+      pos: 26.5,-26.5
+      parent: 1
+  - uid: 1137
+    components:
+    - type: Transform
+      pos: 26.5,-27.5
+      parent: 1
+  - uid: 1138
+    components:
+    - type: Transform
+      pos: 26.5,-19.5
+      parent: 1
+  - uid: 1139
+    components:
+    - type: Transform
+      pos: 4.5,-21.5
+      parent: 1
+  - uid: 1140
+    components:
+    - type: Transform
+      pos: 5.5,-21.5
+      parent: 1
+  - uid: 1141
+    components:
+    - type: Transform
+      pos: 7.5,-21.5
+      parent: 1
+  - uid: 1142
+    components:
+    - type: Transform
+      pos: 8.5,-21.5
+      parent: 1
+  - uid: 1143
+    components:
+    - type: Transform
+      pos: 9.5,-21.5
+      parent: 1
+  - uid: 1144
+    components:
+    - type: Transform
+      pos: 10.5,-21.5
+      parent: 1
+  - uid: 1145
+    components:
+    - type: Transform
+      pos: 11.5,-21.5
+      parent: 1
+  - uid: 1146
+    components:
+    - type: Transform
+      pos: 12.5,-21.5
+      parent: 1
+  - uid: 1147
+    components:
+    - type: Transform
+      pos: 13.5,-21.5
+      parent: 1
+  - uid: 1148
+    components:
+    - type: Transform
+      pos: 14.5,-21.5
+      parent: 1
+  - uid: 1149
+    components:
+    - type: Transform
+      pos: 6.5,-21.5
+      parent: 1
+  - uid: 1150
+    components:
+    - type: Transform
+      pos: 5.5,-17.5
+      parent: 1
+  - uid: 1151
+    components:
+    - type: Transform
+      pos: 6.5,-17.5
+      parent: 1
+  - uid: 1152
+    components:
+    - type: Transform
+      pos: 8.5,-17.5
+      parent: 1
+  - uid: 1153
+    components:
+    - type: Transform
+      pos: 9.5,-17.5
+      parent: 1
+  - uid: 1154
+    components:
+    - type: Transform
+      pos: 10.5,-17.5
+      parent: 1
+  - uid: 1155
+    components:
+    - type: Transform
+      pos: 11.5,-17.5
+      parent: 1
+  - uid: 1156
+    components:
+    - type: Transform
+      pos: 13.5,-17.5
+      parent: 1
+  - uid: 1157
+    components:
+    - type: Transform
+      pos: 7.5,-17.5
+      parent: 1
+  - uid: 1158
+    components:
+    - type: Transform
+      pos: 14.5,-17.5
+      parent: 1
+  - uid: 1159
+    components:
+    - type: Transform
+      pos: 12.5,-17.5
+      parent: 1
+  - uid: 1160
+    components:
+    - type: Transform
+      pos: 15.5,-17.5
+      parent: 1
+  - uid: 1161
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 19.5,-16.5
+      parent: 1
+  - uid: 1162
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,-16.5
+      parent: 1
+  - uid: 1163
+    components:
+    - type: Transform
+      pos: 5.5,-39.5
+      parent: 1
+  - uid: 1164
+    components:
+    - type: Transform
+      pos: 7.5,-39.5
+      parent: 1
+  - uid: 1165
+    components:
+    - type: Transform
+      pos: 11.5,-29.5
+      parent: 1
+  - uid: 1166
+    components:
+    - type: Transform
+      pos: 11.5,-31.5
+      parent: 1
+  - uid: 1167
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-18.5
+      parent: 1
+  - uid: 1168
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-20.5
+      parent: 1
+  - uid: 1169
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 27.5,-21.5
+      parent: 1
+  - uid: 1170
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 29.5,-21.5
+      parent: 1
+  - uid: 1171
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 26.5,-40.5
+      parent: 1
+  - uid: 1172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 26.5,-42.5
+      parent: 1
+  - uid: 1173
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 16.5,-24.5
+      parent: 1
+  - uid: 1174
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 18.5,-24.5
+      parent: 1
+  - uid: 1175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,-18.5
+      parent: 1
+  - uid: 1176
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-29.5
+      parent: 1
+  - uid: 1177
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 23.5,-31.5
+      parent: 1
+  - uid: 1178
+    components:
+    - type: Transform
+      pos: 18.5,-36.5
+      parent: 1
+  - uid: 1179
+    components:
+    - type: Transform
+      pos: 16.5,-36.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 1180
+    components:
+    - type: Transform
+      pos: 27.5,-22.5
+      parent: 1
+- proto: WeaponSubMachineGunC20r
+  entities:
+  - uid: 1181
+    components:
+    - type: Transform
+      pos: 25.60468,-42.54248
+      parent: 1
+- proto: WeaponTurretSyndicate
+  entities:
+  - uid: 1183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-22.5
+      parent: 1
+  - uid: 1184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-16.5
+      parent: 1
+  - uid: 1185
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-44.5
+      parent: 1
+  - uid: 1186
+    components:
+    - type: Transform
+      pos: 3.5,-44.5
+      parent: 1
+  - uid: 1187
+    components:
+    - type: Transform
+      pos: 9.5,-44.5
+      parent: 1
+  - uid: 1188
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 31.5,-38.5
+      parent: 1
+  - uid: 1189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 31.5,-16.5
+      parent: 1
+  - uid: 1190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 25.5,-16.5
+      parent: 1
+...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
added the haunebu V and windmill of peace battlecruiser for admin abuse
## Media
![image](https://github.com/user-attachments/assets/3a331962-5141-4084-9969-757f7446fc8a)
![image](https://github.com/user-attachments/assets/6c22b597-2646-4108-bb21-a503c61d88bb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
**Changelog**
:cl:
- add: Two new shuttles for admins to use